### PR TITLE
Fix incorrect username password issue #10

### DIFF
--- a/lib/spider.js
+++ b/lib/spider.js
@@ -105,7 +105,7 @@ let login = co.wrap(function * (conf) {
     config = conf
     let responseAndBody = yield request.get('/accounts/login/')
     let $ = cheerio.load(responseAndBody[1])
-    let token = $('.form-signin input[name=csrfmiddlewaretoken]').val()
+    let token = $('input[name=csrfmiddlewaretoken]').val()
 
     logger.info('token get')
     debug('token:' + token)


### PR DESCRIPTION
LeetCode has moved csrfmiddlewaretoken input from .form-signin. This issue should be resolved by removing the .form-signin class locator. Verified in local. #10 